### PR TITLE
feat: implement resilient Gemini streaming client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# Rodex
+# Rodex Autonomous Web Automation Platform
+
+This repository contains the scaffolding and initial planning artifacts for the Rodex autonomous web automation platform. The immediate focus is resolving the Gemini streaming reliability issues while laying down infrastructure for the Playwright-based automation engine.
+
+## Repository Layout
+- `docs/` – Planning artifacts and architecture notes.
+- `services/` – Python packages for planner and automation services.
+- `configs/` – Environment and tooling configuration templates.
+- `infra/` – Docker and Terraform infrastructure scaffolding.
+- `tests/` – Placeholder for automated test suites.
+
+## Getting Started
+1. Create a virtual environment (recommended via `uv` or `poetry`).
+2. Install base dependencies:
+   ```bash
+   pip install -e .[planner,automation]
+   ```
+3. Copy `configs/base.env` to `.env` and populate secrets.
+4. Install Playwright browsers:
+   ```bash
+   npx playwright install-deps
+   npx playwright install chromium
+   ```
+
+## Next Steps
+Refer to `docs/initial_development_plan.md` for a detailed 48-hour work breakdown and prioritized tasks.

--- a/configs/base.env
+++ b/configs/base.env
@@ -1,0 +1,6 @@
+# Core environment configuration for local development
+GEMINI_API_KEY="replace-me"
+GEMINI_STREAM_ENDPOINT="wss://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:streamGenerateContent"
+RODEX_ENV="development"
+TELEMETRY_EXPORTER="console"
+REDIS_URL="redis://localhost:6379/0"

--- a/configs/playwright.config.ts
+++ b/configs/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '../tests/automation',
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  reporter: [['list'], ['html', { outputFolder: '../artifacts/playwright-report' }]],
+  use: {
+    baseURL: process.env.RODEX_AUTOMATION_BASE_URL ?? 'http://localhost:8000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    storageState: process.env.PLAYWRIGHT_STORAGE_STATE ?? undefined,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], headless: process.env.CI ? true : false },
+    },
+  ],
+});

--- a/docs/architecture/gemini-streaming.md
+++ b/docs/architecture/gemini-streaming.md
@@ -1,0 +1,44 @@
+# Gemini Streaming Integration Notes
+
+## Objectives
+- Provide low-latency, bidirectional communication between the planner and Gemini model.
+- Ensure resilience through automatic reconnects, heartbeats, and backpressure-aware buffering.
+- Surface telemetry for latency, token usage, and error rates.
+
+## Connection Flow
+1. Acquire API key from secrets manager and instantiate
+   `GeminiStreamConfig` with model + endpoint metadata.
+2. Construct a `GeminiGenerateRequest` and call
+   `GeminiStreamClient.stream(...)`.
+3. The client spins up `GoogleGenerativeAITransport`, which configures the
+   official `google-generativeai` SDK and consumes the streaming generator in a
+   background thread.
+4. Streamed deltas are converted into `GeminiStreamEvent` objects (either
+   `chunk`, `heartbeat`, `error`, or `complete`) that downstream planner code
+   can iterate over asynchronously.
+5. `GeminiTextAccumulator` can stitch together `chunk` events for quick access
+   to the assembled text response.
+
+## Error Handling & Resilience
+- Exponential backoff (base 1s, doubling per attempt up to configurable max)
+  is built into `GeminiStreamClient.stream`. Callers can override retry counts
+  via `GeminiStreamConfig`.
+- Heartbeat events are emitted on a dedicated task to detect idle streams.
+- Transport-level exceptions are surfaced as `GeminiStreamError` instances
+  once retry budgets are exhausted.
+- TODO: Persist unsent payloads in Redis prior to reconnect to guarantee
+  planner state recovery.
+- TODO: Enrich events with correlation IDs and telemetry metadata for tracing.
+
+## Testing Strategy
+- Mock server that simulates message chunking, dropped frames, and rate limiting.
+- Contract tests validating schema of streamed messages.
+- Load test using Locust to measure throughput under concurrent planner sessions.
+
+## Open Questions
+- Should we support alternative transports (pure WebSocket vs. SSE fallback)
+  in addition to the Google SDK wrapper?
+- What authentication scopes + rotation cadence are mandated by the hosting
+  environment?
+- How should token budgeting be enforced for multi-step plans?
+

--- a/docs/initial_development_plan.md
+++ b/docs/initial_development_plan.md
@@ -1,0 +1,104 @@
+# Autonomous Web Automation Platform: Initial Development Plan
+
+## 1. Plan Analysis
+- **Foundational infrastructure**: Requires containerized runtime, IaC for environments, and shared configuration for secrets. Early setup of mono-repo structure, Python package management (Poetry/uv), and CI workflows is critical to support downstream teams.
+- **AI Planning & Decision System**: Gemini streaming integration is the critical path; requires reliable bidirectional streaming client, token budgeting, and stateful planning loop. Needs telemetry and retry logic.
+- **Automation Engine (Playwright)**: Depends on planner outputs. Requires isolated browser workers, task queue, and secure credential management.
+- **Security & Compliance**: Must enforce secrets hygiene, audit logging, and RBAC; can run in parallel with automation engine work once infra scaffolding exists.
+- **Delivery Milestones**: 12-week plan with early emphasis on core planner/automation loop and Gemini streaming fix.
+- **Risks**: Streaming instability, environment drift, and multi-tenant security.
+
+## 2. Highest-Impact Starting Point
+1. **Stabilize Gemini streaming client** to unblock AI planner roadmap.
+2. **Bootstrap shared platform repository** with Python package structure, config templates, and CI guardrails.
+3. **Lay groundwork for Playwright automation service** (env config + test harness).
+
+## 3. Immediate Actionable Steps
+
+### Repository Structure to Create
+```
+.
+├── docs/
+│   └── architecture/
+├── infra/
+│   ├── docker/
+│   └── terraform/
+├── services/
+│   ├── planner/
+│   │   ├── __init__.py
+│   │   └── gemini_stream.py
+│   └── automation/
+│       └── __init__.py
+├── configs/
+│   ├── base.env
+│   └── playwright.config.ts
+└── pyproject.toml
+```
+
+### Files to Create/Populate Today
+- `pyproject.toml`: Declare workspace packages, dependencies (`google-generativeai`, `websockets`, `fastapi`, `playwright`, `pydantic`, `structlog`).
+- `services/planner/gemini_stream.py`: Implement streaming client wrapper with reconnection, heartbeats, and incremental token assembly.
+- `configs/base.env`: Template environment variables (`GEMINI_API_KEY`, streaming endpoints, telemetry toggles).
+- `configs/playwright.config.ts`: Baseline config enabling headed/headless modes, tracing, and secure storage path.
+- `infra/docker/Dockerfile.base`: Base image with Python 3.11, Playwright deps, `uv` installer, non-root user.
+- `infra/terraform/main.tf`: Placeholder for environment modules referencing secrets manager + logging.
+- `docs/architecture/gemini-streaming.md`: Document protocol expectations, retries, budgeting.
+
+### Commands to Run
+```bash
+uv init --package rodex-platform
+uv add fastapi google-generativeai websockets structlog httpx pydantic-settings playwright
+npx playwright install-deps
+npx playwright install chromium
+```
+
+### Gemini Streaming Fix (Priority)
+- Implement async streaming client that:
+  - Uses Gemini streaming endpoint via WebSocket (or HTTP chunked response if required).
+  - Supports **adaptive chunk aggregation** with token limit awareness.
+  - Emits planning events over `asyncio.Queue` for downstream planner.
+  - Implements exponential backoff on disconnect with jitter, max retries configurable.
+  - Persists conversation context to Redis (via planned `rodex.core.state` module).
+- Add integration test scaffold invoking mock Gemini server to validate reconnect & message ordering.
+
+### Parallelizable Tasks
+- **Container 1**: Build Python package + Gemini client implementation.
+- **Container 2**: Set up Docker base image and Playwright dependencies.
+- **Container 3**: Draft Terraform scaffolding and CI workflow (GitHub Actions) concurrently.
+
+### Immediate Blockers/Dependencies
+- Access to Gemini streaming API specs + authentication flow.
+- Decide on package manager (`uv` vs. Poetry) and align team tooling.
+- Secure secrets storage (Vault/GCP Secret Manager) before connecting to live Gemini endpoints.
+
+## 4. 24-48 Hour Work Breakdown
+
+### Day 1 (Hours 0-24)
+1. **Repo Bootstrap (4h)**
+   - Initialize `pyproject.toml` with core dependencies and local dev scripts.
+   - Add pre-commit config (formatting, linting) and CI pipeline skeleton.
+2. **Gemini Streaming Client Skeleton (6h)**
+   - Implement `GeminiStreamClient` with connection lifecycle management.
+   - Write unit tests covering handshake, heartbeat, reconnection.
+3. **Config & Secrets Templates (2h)**
+   - Populate `.env` templates, document required environment variables.
+4. **Automation Engine Setup (3h)**
+   - Create Playwright config, sample task runner stub.
+
+### Day 2 (Hours 24-48)
+1. **Streaming Integration Testing (6h)**
+   - Build mock Gemini server, run end-to-end streaming tests.
+2. **Planner-Orchestrator Interface (4h)**
+   - Define `PlanningEvent` dataclasses and event bus contract.
+3. **Docker & Infra Scaffolding (4h)**
+   - Author base Dockerfile, GitHub Actions workflow for image build.
+4. **Security Foundations (2h)**
+   - Draft RBAC matrix & audit logging requirements in docs.
+5. **Backlog Grooming (2h)**
+   - Capture follow-up tickets for telemetry, rate limiting, compliance tasks.
+
+## 5. Next Deliverables
+- Merge initial repo scaffolding with streaming client skeleton & docs.
+- Establish CI checks (lint, tests) to guard future PRs.
+- Prepare design review doc for Gemini integration before implementing advanced planning features.
+

--- a/infra/docker/Dockerfile.base
+++ b/infra/docker/Dockerfile.base
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/playwright/python:v1.43.0-jammy
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    UV_SYSTEM_PYTHON=1
+
+RUN useradd --create-home --shell /bin/bash rodex
+USER rodex
+WORKDIR /home/rodex/app
+
+# Placeholder for uv/poetry install once tooling is finalized
+CMD ["bash"]

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+variable "project_id" {
+  description = "GCP project that hosts the Rodex platform."
+  type        = string
+}
+
+variable "region" {
+  description = "Default region for deployed resources."
+  type        = string
+  default     = "us-central1"
+}
+
+# TODO: add secret manager, logging sinks, and network modules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "rodex-platform"
+version = "0.1.0"
+description = "Autonomous web automation platform"
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{ name = "Rodex Team" }]
+dependencies = [
+  "structlog>=23.2",
+]
+
+[project.optional-dependencies]
+planner = [
+  "google-generativeai>=0.5.0",
+  "websockets>=11.0",
+  "httpx>=0.27",
+  "pydantic>=2.5",
+  "pydantic-settings>=2.0",
+]
+automation = [
+  "playwright>=1.43",
+]
+
+[tool.setuptools.packages.find]
+where = ["services"]
+

--- a/services/automation/__init__.py
+++ b/services/automation/__init__.py
@@ -1,0 +1,1 @@
+"""Automation service package stub for Playwright-based execution."""

--- a/services/planner/__init__.py
+++ b/services/planner/__init__.py
@@ -1,0 +1,23 @@
+"""Planner service package exposing Gemini streaming integration utilities."""
+
+from .gemini_stream import (
+    GeminiGenerateRequest,
+    GeminiStreamClient,
+    GeminiStreamConfig,
+    GeminiStreamError,
+    GeminiStreamEvent,
+    GeminiTextAccumulator,
+    GoogleGenerativeAITransport,
+    StreamingTransport,
+)
+
+__all__ = [
+    "GeminiGenerateRequest",
+    "GeminiStreamClient",
+    "GeminiStreamConfig",
+    "GeminiStreamError",
+    "GeminiStreamEvent",
+    "GeminiTextAccumulator",
+    "GoogleGenerativeAITransport",
+    "StreamingTransport",
+]

--- a/services/planner/gemini_stream.py
+++ b/services/planner/gemini_stream.py
@@ -1,0 +1,355 @@
+"""High-reliability Gemini streaming client implementation.
+
+This module provides a production-ready streaming wrapper around the Gemini
+Generative AI API.  It improves upon the previous skeleton by adding:
+
+* configurable retry and exponential backoff handling
+* heartbeat emission so downstream planners can detect stalled streams
+* integration with the official ``google-generativeai`` client library
+* text accumulation helpers for simplified consumer usage
+
+The implementation keeps the transport layer pluggable to support unit testing
+and future protocol extensions (e.g. mock transports, SSE/WebSocket variants).
+"""
+
+from __future__ import annotations
+
+import abc
+import asyncio
+import contextlib
+import dataclasses
+import threading
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from typing import Any, Mapping, MutableMapping, Optional
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data models
+
+
+@dataclasses.dataclass(slots=True)
+class GeminiStreamConfig:
+    """Configuration parameters controlling Gemini streaming behaviour."""
+
+    api_key: str
+    model: str
+    endpoint: Optional[str] = None
+    request_timeout: float = 30.0
+    heartbeat_interval: float = 20.0
+    max_retries: int = 3
+    backoff_base: float = 1.0
+    backoff_max: float = 30.0
+    client_options: Optional[Mapping[str, Any]] = None
+
+
+@dataclasses.dataclass(slots=True)
+class GeminiGenerateRequest:
+    """Represents a streaming generation request to Gemini."""
+
+    contents: Sequence[Any]
+    system_instruction: Optional[str] = None
+    tools: Optional[Sequence[Mapping[str, Any]]] = None
+    tool_config: Optional[Mapping[str, Any]] = None
+    generation_config: Optional[Mapping[str, Any]] = None
+    safety_settings: Optional[Sequence[Mapping[str, Any]]] = None
+    request_options: Optional[MutableMapping[str, Any]] = None
+
+
+@dataclasses.dataclass(slots=True)
+class GeminiStreamEvent:
+    """Event emitted during streaming."""
+
+    event: str
+    text: Optional[str] = None
+    raw: Optional[Mapping[str, Any]] = None
+    timestamp: float = dataclasses.field(default_factory=lambda: time.time())
+
+
+@dataclasses.dataclass(slots=True)
+class GeminiTextAccumulator:
+    """Helper that stitches ``GeminiStreamEvent`` chunks into a final string."""
+
+    _parts: list[str] = dataclasses.field(default_factory=list)
+
+    def push(self, event: GeminiStreamEvent) -> None:
+        if event.event == "chunk" and event.text:
+            self._parts.append(event.text)
+
+    @property
+    def text(self) -> str:
+        return "".join(self._parts)
+
+
+# ---------------------------------------------------------------------------
+# Transport abstraction
+
+
+class StreamingTransport(abc.ABC):
+    """Protocol for a Gemini transport implementation."""
+
+    async def __aenter__(self) -> "StreamingTransport":  # pragma: no cover - interface stub
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - interface stub
+        return None
+
+    @abc.abstractmethod
+    async def iter_messages(self) -> AsyncIterator[GeminiStreamEvent]:
+        """Yield streaming events from the underlying transport."""
+
+
+class GoogleGenerativeAITransport(StreamingTransport):
+    """Transport that streams tokens using ``google-generativeai``."""
+
+    def __init__(self, config: GeminiStreamConfig, request: GeminiGenerateRequest) -> None:
+        self._config = config
+        self._request = request
+        self._queue: asyncio.Queue[GeminiStreamEvent] | None = None
+        self._thread: threading.Thread | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    async def __aenter__(self) -> "GoogleGenerativeAITransport":
+        self._loop = asyncio.get_running_loop()
+        self._queue = asyncio.Queue()
+        self._thread = threading.Thread(target=self._run_stream, name="gemini-stream", daemon=True)
+        self._thread.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=0.1)
+        self._thread = None
+        self._queue = None
+        self._loop = None
+
+    async def iter_messages(self) -> AsyncIterator[GeminiStreamEvent]:
+        if self._queue is None:
+            raise RuntimeError("Transport not entered")
+
+        while True:
+            event = await self._queue.get()
+            if event.event == "__end__":
+                break
+            yield event
+
+    # ------------------------------------------------------------------
+    # Private helpers
+
+    def _run_stream(self) -> None:
+        """Execute the synchronous Gemini streaming call in a background thread."""
+
+        try:
+            queue = self._queue
+            loop = self._loop
+            if queue is None or loop is None:
+                return
+
+            genai = self._import_genai()
+
+            client_options = dict(self._config.client_options or {})
+            if self._config.endpoint:
+                client_options.setdefault("api_endpoint", self._config.endpoint)
+            client_options.setdefault("timeout", self._config.request_timeout)
+
+            genai.configure(api_key=self._config.api_key, client_options=client_options)
+
+            model = genai.GenerativeModel(
+                model_name=self._config.model,
+                safety_settings=self._request.safety_settings,
+                generation_config=self._request.generation_config,
+                system_instruction=self._request.system_instruction,
+                tools=self._request.tools,
+                tool_config=self._request.tool_config,
+            )
+
+            request_kwargs: dict[str, Any] = {}
+            if self._request.request_options:
+                request_kwargs["request_options"] = dict(self._request.request_options)
+
+            stream = model.generate_content(
+                list(self._request.contents),
+                stream=True,
+                **request_kwargs,
+            )
+
+            for chunk in stream:
+                payload = self._convert_chunk(chunk)
+                self._run_coro_threadsafe(queue.put(payload), loop)
+
+            self._run_coro_threadsafe(queue.put(GeminiStreamEvent(event="complete")), loop)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception("gemini_stream.transport_error", error=str(exc))
+            queue = self._queue
+            loop = self._loop
+            if queue is not None and loop is not None:
+                error_event = GeminiStreamEvent(event="error", text=str(exc))
+                self._run_coro_threadsafe(queue.put(error_event), loop)
+        finally:
+            queue = self._queue
+            loop = self._loop
+            if queue is not None and loop is not None:
+                self._run_coro_threadsafe(queue.put(GeminiStreamEvent(event="__end__")), loop)
+
+    def _run_coro_threadsafe(self, coro: Awaitable[Any], loop: asyncio.AbstractEventLoop) -> None:
+        asyncio.run_coroutine_threadsafe(coro, loop)
+
+    @staticmethod
+    def _convert_chunk(chunk: Any) -> GeminiStreamEvent:
+        chunk_dict = chunk.to_dict() if hasattr(chunk, "to_dict") else dict(chunk)
+        text = chunk_dict.get("text") or _extract_text_from_chunk(chunk_dict)
+        return GeminiStreamEvent(event="chunk", text=text or "", raw=chunk_dict)
+
+    @staticmethod
+    def _import_genai() -> Any:
+        try:
+            from google import generativeai as genai  # type: ignore
+        except ImportError as exc:  # pragma: no cover - environment guard
+            raise RuntimeError(
+                "google-generativeai is required for GoogleGenerativeAITransport"
+            ) from exc
+        return genai
+
+
+# ---------------------------------------------------------------------------
+# Client orchestration
+
+
+class GeminiStreamError(RuntimeError):
+    """Raised when the streaming client exhausts recovery attempts."""
+
+
+class GeminiStreamClient:
+    """Coordinate streaming sessions, retries, and heartbeats."""
+
+    def __init__(self, config: GeminiStreamConfig) -> None:
+        self._config = config
+
+    async def stream(
+        self,
+        request: GeminiGenerateRequest,
+        *,
+        transport_factory: Callable[[GeminiStreamConfig, GeminiGenerateRequest], StreamingTransport]
+        | None = None,
+    ) -> AsyncIterator[GeminiStreamEvent]:
+        """Stream Gemini events with retry semantics.
+
+        Args:
+            request: Generation payload to send to Gemini.
+            transport_factory: Optional factory producing a ``StreamingTransport``.
+        """
+
+        factory = transport_factory or (lambda c, r: GoogleGenerativeAITransport(c, r))
+
+        attempt = 0
+        last_error: Exception | None = None
+
+        while True:
+            queue: asyncio.Queue[GeminiStreamEvent] = asyncio.Queue()
+            heartbeat_task: asyncio.Task[None] | None = None
+            pump_task = asyncio.create_task(
+                self._pump_events(factory, request, queue),
+                name="gemini-stream-pump",
+            )
+
+            if self._config.heartbeat_interval > 0:
+                heartbeat_task = asyncio.create_task(
+                    self._emit_heartbeats(queue, self._config.heartbeat_interval),
+                    name="gemini-stream-heartbeat",
+                )
+
+            success = True
+
+            try:
+                while True:
+                    event = await queue.get()
+                    if event.event == "__end__":
+                        break
+                    if event.event == "error":
+                        success = False
+                        last_error = RuntimeError(event.text or "Unknown Gemini error")
+                        break
+                    yield event
+            finally:
+                pump_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await pump_task
+                if heartbeat_task:
+                    heartbeat_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await heartbeat_task
+
+            if success:
+                return
+
+            if attempt >= self._config.max_retries:
+                break
+
+            attempt += 1
+            delay = min(self._config.backoff_base * (2 ** (attempt - 1)), self._config.backoff_max)
+            logger.warning(
+                "gemini_stream.retrying",
+                attempt=attempt,
+                delay=delay,
+                error=str(last_error) if last_error else None,
+            )
+            await asyncio.sleep(delay)
+
+        raise GeminiStreamError("Exceeded maximum Gemini streaming retries") from last_error
+
+    async def _pump_events(
+        self,
+        factory: Callable[[GeminiStreamConfig, GeminiGenerateRequest], StreamingTransport],
+        request: GeminiGenerateRequest,
+        queue: asyncio.Queue[GeminiStreamEvent],
+    ) -> None:
+        try:
+            transport = factory(self._config, request)
+            async with transport:
+                async for event in transport.iter_messages():
+                    await queue.put(event)
+        except Exception as exc:  # pylint: disable=broad-except
+            await queue.put(GeminiStreamEvent(event="error", text=str(exc)))
+        finally:
+            await queue.put(GeminiStreamEvent(event="__end__"))
+
+    async def _emit_heartbeats(
+        self, queue: asyncio.Queue[GeminiStreamEvent], interval: float
+    ) -> None:
+        while True:
+            await asyncio.sleep(interval)
+            await queue.put(GeminiStreamEvent(event="heartbeat"))
+
+
+def _extract_text_from_chunk(chunk_dict: Mapping[str, Any]) -> str:
+    candidates = chunk_dict.get("candidates") or []
+    texts: list[str] = []
+    for candidate in candidates:
+        content = candidate.get("content") if isinstance(candidate, Mapping) else None
+        if not content:
+            continue
+        parts = content.get("parts") if isinstance(content, Mapping) else None
+        if not parts:
+            continue
+        for part in parts:
+            text = part.get("text") if isinstance(part, Mapping) else None
+            if text:
+                texts.append(text)
+    return "".join(texts)
+
+
+__all__ = [
+    "GeminiGenerateRequest",
+    "GeminiStreamClient",
+    "GeminiStreamConfig",
+    "GeminiStreamError",
+    "GeminiStreamEvent",
+    "GeminiTextAccumulator",
+    "GoogleGenerativeAITransport",
+    "StreamingTransport",
+]
+

--- a/tests/test_gemini_stream.py
+++ b/tests/test_gemini_stream.py
@@ -1,0 +1,107 @@
+"""Unit tests for the Gemini streaming client."""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from collections.abc import AsyncIterator
+from typing import Sequence
+
+from services.planner.gemini_stream import (
+    GeminiGenerateRequest,
+    GeminiStreamClient,
+    GeminiStreamConfig,
+    GeminiStreamError,
+    GeminiStreamEvent,
+    GeminiTextAccumulator,
+    StreamingTransport,
+)
+
+
+class _ListTransport(StreamingTransport):
+    """Transport that replays a predefined list of events."""
+
+    def __init__(self, events: Sequence[GeminiStreamEvent]) -> None:
+        self._events = list(events)
+
+    async def __aenter__(self) -> "_ListTransport":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def iter_messages(self) -> AsyncIterator[GeminiStreamEvent]:
+        for event in self._events:
+            await asyncio.sleep(0)
+            yield event
+
+
+class _FailingTransport(StreamingTransport):
+    """Transport that raises during entry to trigger retries."""
+
+    async def __aenter__(self) -> "_FailingTransport":  # type: ignore[override]
+        raise RuntimeError("boom")
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def iter_messages(self) -> AsyncIterator[GeminiStreamEvent]:  # pragma: no cover - unreachable
+        yield GeminiStreamEvent(event="complete")
+
+
+class GeminiStreamClientTests(unittest.IsolatedAsyncioTestCase):
+    """High-level behavioural tests for ``GeminiStreamClient``."""
+
+    async def test_stream_successfully_accumulates_chunks(self) -> None:
+        config = GeminiStreamConfig(
+            api_key="test-key",
+            model="models/test",
+            heartbeat_interval=0.0,
+        )
+        client = GeminiStreamClient(config)
+
+        events = [
+            GeminiStreamEvent(event="chunk", text="Hello"),
+            GeminiStreamEvent(event="chunk", text=", world"),
+            GeminiStreamEvent(event="complete"),
+        ]
+
+        accumulator = GeminiTextAccumulator()
+
+        async def run() -> list[GeminiStreamEvent]:
+            output: list[GeminiStreamEvent] = []
+            async for event in client.stream(
+                GeminiGenerateRequest(contents=[{"role": "user", "parts": [{"text": "Hi"}]}]),
+                transport_factory=lambda _c, _r: _ListTransport(events),
+            ):
+                accumulator.push(event)
+                output.append(event)
+            return output
+
+        emitted = await run()
+        self.assertEqual(accumulator.text, "Hello, world")
+        self.assertEqual([event.event for event in emitted], ["chunk", "chunk", "complete"])
+
+    async def test_stream_raises_after_retry_budget_exhausted(self) -> None:
+        config = GeminiStreamConfig(
+            api_key="test-key",
+            model="models/test",
+            heartbeat_interval=0.0,
+            max_retries=2,
+        )
+        client = GeminiStreamClient(config)
+
+        async def consume() -> None:
+            async for _ in client.stream(
+                GeminiGenerateRequest(contents=[{"role": "user", "parts": [{"text": "Hi"}]}]),
+                transport_factory=lambda _c, _r: _FailingTransport(),
+            ):
+                pass
+
+        with self.assertRaises(GeminiStreamError):
+            await consume()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- replace the Gemini streaming skeleton with a production-ready client that wraps the google-generativeai transport, retry/backoff control, and heartbeat events
- document the updated streaming connection flow and resilience behaviour for planners
- add isolated unit tests validating chunk aggregation and retry exhaustion handling

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_b_68e0786354b8832fa0196bc0b1333675