### PR TITLE
Implement landing page APIs and tests

### DIFF
--- a/docs/landing_page_spec.md
+++ b/docs/landing_page_spec.md
@@ -1,0 +1,110 @@
+# Landing Experience Specification
+
+## Overview
+This document defines the implementation contract for the Rodex landing experience so that the shipped UI matches the provided design ("What are we coding next?" workspace selector screen). It captures the user interface structure, focus management requirements, and the supporting backend APIs required to populate the view.
+
+## Screen Structure
+1. **Global Header**
+   - Left: product logo.
+   - Right: profile avatar with status indicator.
+2. **Workspace Selector Row**
+   - Pills for organization (e.g., `monorepo`) and branch (e.g., `main`).
+   - Tabs for `Tasks` and `Archive` views with badge counts.
+3. **Hero Panel**
+   - Title: "What are we coding next?" (H1, 32px desktop).
+   - Subtitle: short hint text (e.g., "Use / to focus the composer").
+   - Prompt composer with placeholder "Start typing or paste context…".
+   - Primary actions: `Ask` (secondary emphasis) and `Code` (primary emphasis) buttons.
+   - Keyboard hint: `/` focuses the composer, `Cmd/Ctrl+Enter` submits.
+4. **Task List**
+   - Each task card includes title, relative timestamp, repo label, diff stats (+/-), and badge (Merged, In Review, etc.).
+   - `Archive` tab reuses card layout but dims metadata.
+
+## Focus Management
+- The `Code` button receives default focus when the page loads to match the design highlight.
+- Provide a skip link that jumps directly to the prompt composer.
+- Use `:focus-visible` outlines on all interactive elements; align outlines with brand color `#9F6BFF` (per design palette) at 2px thickness.
+- Implement roving `tabindex` inside the task list to keep focus within a single card while arrow keys move between cards.
+- `/` keyboard shortcut invokes `focus()` on the prompt textarea without interfering with native typing.
+- Restore focus to the last interacted element after modal or toast interactions, respecting `prefers-reduced-motion`.
+
+## Responsive Behavior
+- **≥1280px**: Content centered within 960px max width with the hero and task list in a vertical stack.
+- **768–1279px**: Reduce hero padding by 16px, stack the Ask/Code buttons vertically with 12px gap.
+- **<768px**: Convert workspace pills into a horizontally scrollable list; ensure 44px touch targets.
+
+## API Contracts
+The landing screen relies on three core endpoints served by the planner service.
+
+### GET `/api/workspaces`
+Returns the workspaces and branches available to the user.
+```json
+{
+  "workspaces": [
+    {
+      "id": "monorepo",
+      "name": "Monorepo",
+      "branches": [
+        { "id": "main", "label": "main", "is_default": true }
+      ]
+    }
+  ]
+}
+```
+- Cache for 5 minutes client-side.
+- Include `etag` headers for optimistic concurrency.
+
+### GET `/api/tasks?workspace=<id>&branch=<id>&status=<active|archived>`
+Delivers task cards for the selected filters.
+```json
+{
+  "tasks": [
+    {
+      "id": "task_123",
+      "title": "Diagnose issues with status updates",
+      "status": "merged",
+      "repo": "monorepo",
+      "branch": "main",
+      "created_at": "2025-01-26T22:10:00Z",
+      "merged_at": "2025-01-26T23:45:00Z",
+      "diff": { "added": 76, "removed": 47 }
+    }
+  ]
+}
+```
+- Support pagination via `cursor` query parameter.
+- Provide `Cache-Control: no-store` to keep data fresh.
+- Map `status` to badges (`merged`, `in_review`, `draft`).
+
+### POST `/api/prompts`
+Submits the composer content for processing.
+```json
+{
+  "workspace_id": "monorepo",
+  "branch_id": "main",
+  "mode": "code",  // or "ask"
+  "prompt": "Summarize the Gemini streaming outage workarounds."
+}
+```
+Responses include a `job_id` for streaming progress updates.
+
+Errors return problem+json payloads with actionable messages and field-level pointers for inline validation.
+
+## State Management & Loading
+- Use React Query (or equivalent) to manage caching, retries, and background refresh of task data.
+- Display skeleton cards while fetching tasks; ensure skeletons retain focusable structure for screen readers using `aria-busy`.
+- Maintain optimistic UI when creating prompts: append a placeholder task while awaiting backend confirmation.
+
+## Analytics & Telemetry
+- Track events for `landing.page_view`, `prompt.submitted`, `task.card_opened`, and `tab.changed` with workspace/branch metadata.
+- Respect user consent settings stored in `localStorage` under `rodex:telemetry-consent`.
+
+## Testing Checklist
+- Keyboard-only walkthrough verifies default focus, skip links, and `/` shortcut.
+- Cypress end-to-end test ensures API responses render correct counts and badges.
+- Visual regression test compares hero section against design tokens with 0.1% tolerance.
+- Contract tests for the three APIs using `pytest-httpx` mocks.
+
+## Open Questions
+- Confirm final palette tokens for badge colors and button gradients.
+- Determine whether archived tasks require server-side filtering or client-side transformation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ planner = [
   "google-generativeai>=0.5.0",
   "websockets>=11.0",
   "httpx>=0.27",
+  "fastapi>=0.111",
 ]
 automation = [
   "playwright>=1.43",

--- a/services/planner/__init__.py
+++ b/services/planner/__init__.py
@@ -10,6 +10,19 @@ from .gemini_stream import (  # noqa: F401
     GoogleGenerativeAITransport,
     StreamingTransport,
 )
+from .landing_api import (  # noqa: F401
+    Branch,
+    LandingDataStore,
+    PromptResponse,
+    PromptSubmission,
+    Task,
+    TaskCollection,
+    TaskDiff,
+    TasksResponse,
+    WorkspacesResponse,
+    Workspace,
+    create_app,
+)
 from .project_settings import GeminiEnvironment, ProjectSettings  # noqa: F401
 
 __all__ = [
@@ -23,4 +36,15 @@ __all__ = [
     "StreamingTransport",
     "GeminiEnvironment",
     "ProjectSettings",
+    "Branch",
+    "Workspace",
+    "WorkspacesResponse",
+    "TaskDiff",
+    "Task",
+    "TaskCollection",
+    "TasksResponse",
+    "PromptSubmission",
+    "PromptResponse",
+    "LandingDataStore",
+    "create_app",
 ]

--- a/services/planner/landing_api.py
+++ b/services/planner/landing_api.py
@@ -1,0 +1,315 @@
+"""FastAPI application exposing the landing page data contract.
+
+The previous iteration of this repository only contained planning documents
+describing the desired API shape for the landing experience.  This module
+implements those contracts so that the frontend can interact with a working
+service.  The implementation keeps the data store pluggable which allows unit
+tests to exercise behaviour without relying on network calls or external
+databases.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Mapping, MutableMapping, Sequence
+
+from fastapi import FastAPI, HTTPException, Query, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+__all__ = [
+    "Branch",
+    "LandingDataStore",
+    "PromptResponse",
+    "PromptSubmission",
+    "Task",
+    "TaskCollection",
+    "TaskDiff",
+    "TasksResponse",
+    "WorkspacesResponse",
+    "Workspace",
+    "create_app",
+]
+
+
+class Branch(BaseModel):
+    """Represents a workspace branch that can be targeted by prompts."""
+
+    id: str
+    label: str
+    is_default: bool = False
+
+
+class Workspace(BaseModel):
+    """Workspace surfaced on the landing page selector."""
+
+    id: str
+    name: str
+    branches: list[Branch]
+
+
+class WorkspacesResponse(BaseModel):
+    """Envelope returned by the ``/api/workspaces`` endpoint."""
+
+    workspaces: list[Workspace]
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class TaskDiff(BaseModel):
+    """Diff metadata rendered on task cards."""
+
+    added: int = Field(ge=0)
+    removed: int = Field(ge=0)
+
+
+class Task(BaseModel):
+    """Task model displayed within the landing screen."""
+
+    id: str
+    title: str
+    status: str
+    repo: str
+    branch: str
+    created_at: datetime
+    merged_at: datetime | None = None
+    diff: TaskDiff
+
+
+class TaskCollection(str, Enum):
+    """Logical grouping of tasks for filtering."""
+
+    ACTIVE = "active"
+    ARCHIVED = "archived"
+
+
+class TasksResponse(BaseModel):
+    """Response payload returned by ``/api/tasks``."""
+
+    tasks: list[Task]
+    next_cursor: str | None = None
+
+
+class PromptSubmission(BaseModel):
+    """Incoming payload accepted by the ``/api/prompts`` endpoint."""
+
+    workspace_id: str
+    branch_id: str
+    mode: str = Field(pattern="^(ask|code)$")
+    prompt: str
+
+    def normalised_prompt(self) -> str:
+        """Return the trimmed prompt text."""
+
+        return self.prompt.strip()
+
+
+class PromptResponse(BaseModel):
+    """Response returned after a prompt submission is accepted."""
+
+    job_id: str
+    accepted_at: datetime
+
+
+class LandingDataStore:
+    """In-memory backing store that fulfils landing API queries."""
+
+    def __init__(
+        self,
+        *,
+        workspaces: Sequence[Workspace] | None = None,
+        tasks: Mapping[tuple[str, str, TaskCollection], Sequence[Task]] | None = None,
+    ) -> None:
+        self._workspaces: list[Workspace] = [
+            workspace.model_copy(deep=True)
+            for workspace in (workspaces if workspaces is not None else self._default_workspaces())
+        ]
+        self._workspace_index: dict[str, Workspace] = {ws.id: ws for ws in self._workspaces}
+        default_tasks = tasks if tasks is not None else self._default_tasks()
+        self._tasks: dict[tuple[str, str, TaskCollection], list[Task]] = {}
+        for key, collection in default_tasks.items():
+            self._tasks[key] = [task.model_copy(deep=True) for task in collection]
+
+    # ------------------------------------------------------------------
+    # Default dataset used when no external source is provided
+
+    def _default_workspaces(self) -> list[Workspace]:
+        return [
+            Workspace(
+                id="monorepo",
+                name="Monorepo",
+                branches=[
+                    Branch(id="main", label="main", is_default=True),
+                    Branch(id="experimental", label="experimental"),
+                ],
+            )
+        ]
+
+    def _default_tasks(self) -> MutableMapping[tuple[str, str, TaskCollection], list[Task]]:
+        created = datetime(2025, 1, 26, 22, 10, tzinfo=timezone.utc)
+        merged = datetime(2025, 1, 26, 23, 45, tzinfo=timezone.utc)
+        return {
+            ("monorepo", "main", TaskCollection.ACTIVE): [
+                Task(
+                    id="task_123",
+                    title="Diagnose issues with status updates",
+                    status="in_review",
+                    repo="monorepo",
+                    branch="main",
+                    created_at=created,
+                    diff=TaskDiff(added=76, removed=47),
+                ),
+                Task(
+                    id="task_124",
+                    title="Document Gemini streaming mitigation plan",
+                    status="draft",
+                    repo="monorepo",
+                    branch="main",
+                    created_at=created,
+                    diff=TaskDiff(added=12, removed=3),
+                ),
+            ],
+            ("monorepo", "main", TaskCollection.ARCHIVED): [
+                Task(
+                    id="task_120",
+                    title="Stabilise WebSocket reconnect flow",
+                    status="merged",
+                    repo="monorepo",
+                    branch="main",
+                    created_at=created,
+                    merged_at=merged,
+                    diff=TaskDiff(added=33, removed=5),
+                )
+            ],
+        }
+
+    # ------------------------------------------------------------------
+    # Public API used by the FastAPI routes
+
+    def workspaces(self) -> list[Workspace]:
+        """Return a deep copy of the known workspaces."""
+
+        return [workspace.model_copy(deep=True) for workspace in self._workspaces]
+
+    def workspaces_etag(self) -> str:
+        """Stable ETag derived from the workspace payload."""
+
+        payload = [ws.model_dump(mode="json", round_trip=True) for ws in self._workspaces]
+        digest = hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8"))
+        return digest.hexdigest()
+
+    def list_tasks(
+        self,
+        workspace_id: str,
+        branch_id: str,
+        collection: TaskCollection,
+        *,
+        cursor: str | None = None,
+        page_size: int = 25,
+    ) -> tuple[list[Task], str | None]:
+        """Return tasks for the given selection along with an optional cursor."""
+
+        workspace = self._workspace_index.get(workspace_id)
+        if workspace is None:
+            raise KeyError("workspace_not_found")
+
+        branch_ids = {branch.id for branch in workspace.branches}
+        if branch_id not in branch_ids:
+            raise KeyError("branch_not_found")
+
+        key = (workspace_id, branch_id, collection)
+        collection_tasks = self._tasks.get(key, [])
+
+        start_index = 0
+        if cursor:
+            try:
+                start_index = int(cursor)
+            except ValueError as exc:  # pragma: no cover - defensive
+                raise ValueError("invalid_cursor") from exc
+            if start_index < 0:
+                raise ValueError("invalid_cursor")
+
+        end_index = start_index + page_size
+        page = [task.model_copy(deep=True) for task in collection_tasks[start_index:end_index]]
+        next_cursor = str(end_index) if end_index < len(collection_tasks) else None
+        return page, next_cursor
+
+    def create_prompt(self, submission: PromptSubmission) -> PromptResponse:
+        """Validate and record a prompt submission."""
+
+        workspace = self._workspace_index.get(submission.workspace_id)
+        if workspace is None:
+            raise KeyError("workspace_not_found")
+
+        if submission.branch_id not in {branch.id for branch in workspace.branches}:
+            raise KeyError("branch_not_found")
+
+        prompt_text = submission.normalised_prompt()
+        if not prompt_text:
+            raise ValueError("prompt_required")
+
+        job_id = f"job_{uuid.uuid4().hex}"
+        return PromptResponse(job_id=job_id, accepted_at=datetime.now(timezone.utc))
+
+
+def create_app(data_store: LandingDataStore | None = None) -> FastAPI:
+    """Instantiate the FastAPI application exposing the landing endpoints."""
+
+    store = data_store or LandingDataStore()
+    app = FastAPI(title="Rodex Landing API", version="1.0.0")
+
+    @app.get("/api/workspaces", response_model=WorkspacesResponse)
+    def get_workspaces() -> JSONResponse:
+        response_model = WorkspacesResponse(workspaces=store.workspaces())
+        payload = response_model.model_dump(mode="json")
+        headers = {
+            "Cache-Control": "public, max-age=300, must-revalidate",
+            "ETag": store.workspaces_etag(),
+        }
+        return JSONResponse(content=payload, headers=headers)
+
+    @app.get("/api/tasks", response_model=TasksResponse)
+    def get_tasks(
+        workspace: str = Query(..., description="Workspace identifier"),
+        branch: str = Query(..., description="Branch identifier"),
+        collection: TaskCollection = Query(
+            ..., alias="status", description="Collection filter"
+        ),
+        cursor: str | None = Query(None, description="Pagination cursor"),
+    ) -> JSONResponse:
+        try:
+            tasks, next_cursor = store.list_tasks(
+                workspace, branch, collection, cursor=cursor
+            )
+        except KeyError as exc:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+        payload = TasksResponse(tasks=tasks, next_cursor=next_cursor).model_dump(mode="json")
+        return JSONResponse(content=payload, headers={"Cache-Control": "no-store"})
+
+    @app.post(
+        "/api/prompts",
+        response_model=PromptResponse,
+        status_code=status.HTTP_202_ACCEPTED,
+    )
+    def submit_prompt(submission: PromptSubmission) -> JSONResponse:
+        try:
+            result = store.create_prompt(submission)
+        except KeyError as exc:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+        return JSONResponse(
+            content=result.model_dump(mode="json"),
+            status_code=status.HTTP_202_ACCEPTED,
+            headers={"Cache-Control": "no-store"},
+        )
+
+    return app
+

--- a/tests/test_landing_api.py
+++ b/tests/test_landing_api.py
@@ -1,0 +1,128 @@
+"""Integration tests for the landing FastAPI application."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from services.planner.landing_api import (
+    Branch,
+    LandingDataStore,
+    Task,
+    TaskCollection,
+    TaskDiff,
+    Workspace,
+    create_app,
+)
+
+
+def _build_store(task_count: int = 3) -> LandingDataStore:
+    """Return a data store with deterministic workspaces and tasks."""
+
+    workspace = Workspace(
+        id="monorepo",
+        name="Monorepo",
+        branches=[Branch(id="main", label="main", is_default=True)],
+    )
+    created_at = datetime(2025, 1, 26, 22, 10, tzinfo=timezone.utc)
+    tasks = [
+        Task(
+            id=f"task_{index:03d}",
+            title=f"Task {index}",
+            status="merged" if index % 2 == 0 else "in_review",
+            repo="monorepo",
+            branch="main",
+            created_at=created_at,
+            diff=TaskDiff(added=index, removed=index // 2),
+        )
+        for index in range(task_count)
+    ]
+    task_map = {("monorepo", "main", TaskCollection.ACTIVE): tasks}
+    return LandingDataStore(workspaces=[workspace], tasks=task_map)
+
+
+def test_get_workspaces_returns_cache_headers() -> None:
+    client = TestClient(create_app(_build_store()))
+
+    response = client.get("/api/workspaces")
+
+    assert response.status_code == 200
+    assert response.json()["workspaces"][0]["id"] == "monorepo"
+    assert "ETag" in response.headers
+    assert response.headers["Cache-Control"].startswith("public")
+
+
+def test_get_tasks_supports_cursor_pagination() -> None:
+    # request more tasks than the default page size (25) to surface pagination
+    client = TestClient(create_app(_build_store(task_count=30)))
+
+    first_page = client.get(
+        "/api/tasks",
+        params={"workspace": "monorepo", "branch": "main", "status": "active"},
+    )
+
+    assert first_page.status_code == 200
+    body = first_page.json()
+    assert len(body["tasks"]) == 25
+    assert body["next_cursor"] == "25"
+
+    second_page = client.get(
+        "/api/tasks",
+        params={
+            "workspace": "monorepo",
+            "branch": "main",
+            "status": "active",
+            "cursor": body["next_cursor"],
+        },
+    )
+
+    assert second_page.status_code == 200
+    assert len(second_page.json()["tasks"]) == 5
+    assert second_page.json()["next_cursor"] is None
+
+
+def test_get_tasks_unknown_workspace_returns_404() -> None:
+    client = TestClient(create_app(_build_store()))
+
+    response = client.get(
+        "/api/tasks",
+        params={"workspace": "missing", "branch": "main", "status": "active"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_submit_prompt_returns_job_id() -> None:
+    client = TestClient(create_app(_build_store()))
+
+    submission = {
+        "workspace_id": "monorepo",
+        "branch_id": "main",
+        "mode": "code",
+        "prompt": "Summarise the latest automation fixes.",
+    }
+    response = client.post("/api/prompts", json=submission)
+
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload["job_id"].startswith("job_")
+    assert "T" in payload["accepted_at"]
+    assert response.headers["Cache-Control"] == "no-store"
+
+
+@pytest.mark.parametrize(
+    "invalid_payload",
+    [
+        {"workspace_id": "monorepo", "branch_id": "missing", "mode": "code", "prompt": "text"},
+        {"workspace_id": "monorepo", "branch_id": "main", "mode": "code", "prompt": "   "},
+    ],
+)
+def test_submit_prompt_validation_errors(invalid_payload: dict[str, str]) -> None:
+    client = TestClient(create_app(_build_store()))
+
+    response = client.post("/api/prompts", json=invalid_payload)
+
+    # 404 for unknown branches, 400 for empty prompt
+    assert response.status_code in {400, 404}


### PR DESCRIPTION
## Summary
- capture the UX contract for the landing screen, including layout, focus handling, and responsive breakpoints
- define supporting API contracts, state management guidance, and validation/testing expectations
- implement FastAPI landing endpoints with an in-memory data store, caching headers, and prompt validation
- expose the landing API via the planner package and cover it with integration tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e0a152dc14832fb6ea7812555d7b02