### PR TITLE
Add Railway deployment template and health endpoint

### DIFF
--- a/.railwayignore
+++ b/.railwayignore
@@ -1,0 +1,17 @@
+# Ignore development artifacts that do not need to be uploaded to Railway builds
+.git
+.github
+pytest.ini
+reports/
+.tests
+__pycache__/
+*.pyc
+*.pyo
+.env
+.env.*
+.venv/
+.cache/
+.mypy_cache/
+.pytest_cache/
+node_modules/
+docs/

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn services.planner.landing_api:create_app --host 0.0.0.0 --port ${PORT:-8080}

--- a/docs/deployments/railway-template.md
+++ b/docs/deployments/railway-template.md
@@ -1,0 +1,67 @@
+# Railway Deployment Template
+
+This guide explains how to deploy Rodex on [Railway](https://railway.app) using the project template files added in this repository.
+
+## Overview
+
+The provided template definition and Nixpacks configuration are intended to run alongside the following Railway resources:
+
+- **rodex-app** – FastAPI-based planner service exposed via Uvicorn.
+- **PostgreSQL** – Optional relational store for persisting automation data.
+- **Redis** – Optional cache layer for coordinating automation jobs.
+- **Persistent volume** – Stores Playwright browser artifacts to avoid repeated downloads.
+
+The generated deployment uses [Nixpacks](https://nixpacks.com) to install Python 3.11, Playwright dependencies, and Chromium before runtime.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| [`railway.json`](../../railway.json) | Primary template definition used by Railway (build + deploy settings). |
+| [`nixpacks.toml`](../../nixpacks.toml) | Customises the build image with required system packages. |
+| [`Procfile`](../../Procfile) | Declares the `web` process that serves the FastAPI application. |
+| [`.railwayignore`](../../.railwayignore) | Reduces build context by ignoring local-only artefacts. |
+
+## Required Environment Variables
+
+| Variable | Description |
+| --- | --- |
+| `GEMINI_API_KEY` | Google Gemini API key used by the planner. |
+| `ENVIRONMENT` | Deployment environment indicator (defaults to `production`). |
+| `PORT` | HTTP port (defaults to `8080`). |
+| `PLAYWRIGHT_BROWSERS_PATH` | Location for cached Playwright browsers (`/data/playwright/browsers`). |
+| `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` | Leave `0` so Chromium is installed during build. |
+| `LOG_LEVEL` | Application log verbosity (defaults to `INFO`). |
+
+When the PostgreSQL and Redis template services are included, Railway automatically injects `DATABASE_URL` and `REDIS_URL` environment variables into the application service.
+
+## Deployment Steps
+
+1. **Create a new Railway project** and import the Rodex repository.
+2. **Set environment variables** using the Railway dashboard or CLI:
+   ```bash
+   railway variables set GEMINI_API_KEY=your-key-here
+   railway variables set ENVIRONMENT=production LOG_LEVEL=INFO
+   ```
+3. **Create and attach a persistent volume** (e.g. `playwright-cache`) to `/data/playwright` so browser downloads are cached between deploys.
+4. **Deploy the template**. Railway will build the image with Playwright dependencies and start the Uvicorn server.
+5. **Validate the deployment**:
+   ```bash
+   railway run python -m playwright --version
+   railway run curl "$RAILWAY_PUBLIC_DOMAIN/api/workspaces"
+   ```
+
+## Health Checks and Monitoring
+
+- The template configures a `/health` endpoint within `services/planner/landing_api.py` for Railway’s HTTP health checks.
+- Restart policy is set to retry up to 10 times on failure.
+- Consider enabling Railway metrics dashboards to monitor memory usage during heavy Playwright sessions.
+
+## Customisation Tips
+
+- Update `Procfile` if you split the automation engine into a separate worker process.
+- Modify `nixpacks.toml` to install additional system packages required by Playwright extensions.
+- Use additional Railway environment groups to share secrets across environments.
+- If you need more than 1 GB RAM, adjust the service plan or scale vertically.
+
+With these files in place, new deployments can be bootstrapped quickly from the Railway template gallery or via the CLI.

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,16 @@
+[phases.setup]
+nixPkgs = ["python311", "nodejs_20"]
+
+[phases.build]
+cmds = [
+  "python -m pip install --upgrade pip",
+  "pip install -e .[planner,automation]",
+  "python -m playwright install-deps",
+  "python -m playwright install chromium"
+]
+
+[variables]
+PLAYWRIGHT_BROWSERS_PATH = "/data/playwright/browsers"
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "0"
+ENVIRONMENT = "production"
+LOG_LEVEL = "INFO"

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "python -m pip install --upgrade pip && pip install -e .[planner,automation] && python -m playwright install-deps && python -m playwright install chromium"
+  },
+  "deploy": {
+    "startCommand": "uvicorn services.planner.landing_api:create_app --host 0.0.0.0 --port ${PORT:-8080}",
+    "healthcheckPath": "/health",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/services/planner/landing_api.py
+++ b/services/planner/landing_api.py
@@ -261,6 +261,15 @@ def create_app(data_store: LandingDataStore | None = None) -> FastAPI:
     store = data_store or LandingDataStore()
     app = FastAPI(title="Rodex Landing API", version="1.0.0")
 
+    @app.get("/health")
+    def health_check() -> JSONResponse:
+        """Return a lightweight status response for platform health checks."""
+
+        return JSONResponse(
+            content={"status": "ok"},
+            headers={"Cache-Control": "no-store"},
+        )
+
     @app.get("/api/workspaces", response_model=WorkspacesResponse)
     def get_workspaces() -> JSONResponse:
         response_model = WorkspacesResponse(workspaces=store.workspaces())

--- a/tests/test_landing_api.py
+++ b/tests/test_landing_api.py
@@ -126,3 +126,13 @@ def test_submit_prompt_validation_errors(invalid_payload: dict[str, str]) -> Non
 
     # 404 for unknown branches, 400 for empty prompt
     assert response.status_code in {400, 404}
+
+
+def test_health_endpoint_returns_ok_status() -> None:
+    client = TestClient(create_app(_build_store()))
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    assert response.headers["Cache-Control"] == "no-store"


### PR DESCRIPTION
## Summary
- add a Railway deployment definition, Procfile, and build ignore to streamline template creation
- add a Nixpacks configuration and deployment guide documenting environment variables and setup steps
- expose a `/health` endpoint with a regression test for template health checks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e0a7886534832f8dff415f565e833d