### PR TITLE
Configure Railway template for monorepo services

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ This repository contains the scaffolding and initial planning artifacts for the 
 ## Next Steps
 Refer to `docs/initial_development_plan.md` for a detailed 48-hour work breakdown and prioritized tasks.
 
+# Deploy to Railway
+
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/YOUR_TEMPLATE_ID)
+
+### What gets deployed
+- **Planner Service** – Gemini-powered planning API exposed via FastAPI.
+- **Automation Service** – Playwright automation runtime with shared browser cache.
+- **PostgreSQL** – Primary relational datastore for planner and automation jobs.
+- **Redis** – Shared cache and queue backend.
+
+### Post-deployment checklist
+1. Set the `GEMINI_API_KEY` secret on the planner service (it propagates to automation).
+2. Confirm that `planner` and `automation` services resolve to each other using their private domains.
+3. Tail the planner logs to verify that health checks succeed before inviting consumers.
+
 # Rodex
 
 This repository houses evaluation artifacts for runtime environments supporting AI-generated code execution. See [`reports/runtime_evaluation.md`](reports/runtime_evaluation.md) for the full comparison of WebContainer, managed containers, and serverless functions.

--- a/configs/railway.env.template
+++ b/configs/railway.env.template
@@ -1,0 +1,22 @@
+# === Shared Variables ===
+ENVIRONMENT=production
+LOG_LEVEL=INFO
+GEMINI_API_KEY=${{secret(40)}}
+
+# === Database ===
+DATABASE_URL=${{postgres.DATABASE_URL}}
+REDIS_URL=${{redis.REDIS_URL}}
+
+# === Service URLs (Internal Communication) ===
+PLANNER_URL=${{planner.RAILWAY_PRIVATE_DOMAIN}}
+AUTOMATION_URL=${{automation.RAILWAY_PRIVATE_DOMAIN}}
+
+# === Planner Service ===
+PLANNER_PORT=8080
+PLANNER_WORKERS=2
+
+# === Automation Service ===
+AUTOMATION_PORT=8081
+AUTOMATION_WORKERS=1
+PLAYWRIGHT_BROWSERS_PATH=/data/browsers
+HEADLESS=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ planner = [
 ]
 automation = [
   "playwright>=1.43",
+  "fastapi>=0.111",
+  "uvicorn[standard]>=0.29",
 ]
 
 [tool.setuptools.packages.find]

--- a/railway.template.json
+++ b/railway.template.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "name": "Rodex - Autonomous Web Automation",
+  "description": "AI-powered task planning and browser automation with Gemini and Playwright.",
+  "icon": "🤖",
+  "tags": ["automation", "ai", "playwright", "python"],
+  "repository": "https://github.com/codedwithlikhon/Rodex",
+  "services": {
+    "planner": {
+      "name": "Planner Service",
+      "description": "Gemini-powered task planning engine.",
+      "source": {
+        "repo": "codedwithlikhon/Rodex",
+        "branch": "main"
+      },
+      "rootDirectory": "/services/planner",
+      "build": {
+        "builder": "NIXPACKS",
+        "buildCommand": "pip install -e ../../.[planner] && npx playwright install chromium"
+      },
+      "deploy": {
+        "startCommand": "uvicorn landing_api:create_app --host 0.0.0.0 --port ${PORT:-8080}",
+        "healthcheckPath": "/health",
+        "restartPolicyType": "ON_FAILURE"
+      },
+      "env": {
+        "SERVICE_NAME": {
+          "description": "Service identifier.",
+          "default": "planner"
+        },
+        "GEMINI_API_KEY": {
+          "description": "Google Gemini API key used for planning prompts.",
+          "generator": {
+            "type": "secret",
+            "length": 40
+          }
+        },
+        "PORT": {
+          "description": "HTTP port for the planner service.",
+          "default": "8080"
+        },
+        "DATABASE_URL": "${{postgres.DATABASE_URL}}",
+        "REDIS_URL": "${{redis.REDIS_URL}}",
+        "AUTOMATION_URL": "http://${{automation.RAILWAY_PRIVATE_DOMAIN}}"
+      }
+    },
+    "automation": {
+      "name": "Automation Service",
+      "description": "Playwright-based browser automation engine.",
+      "source": {
+        "repo": "codedwithlikhon/Rodex",
+        "branch": "main"
+      },
+      "rootDirectory": "/services/automation",
+      "build": {
+        "builder": "NIXPACKS",
+        "buildCommand": "pip install -e ../../.[automation] && npx playwright install-deps && npx playwright install chromium"
+      },
+      "deploy": {
+        "startCommand": "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8081}",
+        "healthcheckPath": "/health",
+        "restartPolicyType": "ON_FAILURE"
+      },
+      "env": {
+        "SERVICE_NAME": {
+          "description": "Service identifier.",
+          "default": "automation"
+        },
+        "GEMINI_API_KEY": "${{planner.GEMINI_API_KEY}}",
+        "PORT": {
+          "description": "HTTP port for the automation service.",
+          "default": "8081"
+        },
+        "DATABASE_URL": "${{postgres.DATABASE_URL}}",
+        "REDIS_URL": "${{redis.REDIS_URL}}",
+        "PLANNER_URL": "http://${{planner.RAILWAY_PRIVATE_DOMAIN}}",
+        "PLAYWRIGHT_BROWSERS_PATH": "/data/browsers",
+        "HEADLESS": "true"
+      },
+      "volumes": [
+        {
+          "name": "playwright-cache",
+          "mountPath": "/data"
+        }
+      ]
+    },
+    "postgres": {
+      "name": "PostgreSQL",
+      "template": "postgresql",
+      "env": {
+        "POSTGRES_DB": "rodex",
+        "POSTGRES_USER": "rodex",
+        "POSTGRES_PASSWORD": "${{secret(32)}}"
+      }
+    },
+    "redis": {
+      "name": "Redis Cache",
+      "template": "redis"
+    }
+  }
+}

--- a/services/automation/main.py
+++ b/services/automation/main.py
@@ -1,0 +1,63 @@
+"""Placeholder entrypoint for the automation service.
+
+This keeps the Railway deployment template functional until the
+Playwright automation runtime is implemented.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from fastapi import FastAPI
+
+try:
+    import uvicorn
+except ModuleNotFoundError:  # pragma: no cover - fallback path
+    uvicorn = None  # type: ignore[assignment]
+
+__all__ = ["app", "main"]
+
+
+logger = logging.getLogger("automation")
+
+
+app = FastAPI()
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Return a minimal health payload for deployment checks."""
+
+    return {"status": "ok"}
+
+
+async def _serve() -> None:
+    """Run the FastAPI application using Uvicorn."""
+
+    assert uvicorn is not None  # guard for type checkers
+    config = uvicorn.Config(app, host="0.0.0.0", port=int(os.getenv("PORT", "8081")))
+    server = uvicorn.Server(config)
+    await server.serve()
+
+
+async def _idle() -> None:
+    """Fallback loop used when Uvicorn is unavailable."""
+
+    logger.warning("Uvicorn is unavailable; automation service is idling.")
+    while True:
+        await asyncio.sleep(3600)
+
+
+def main() -> None:
+    """Entrypoint executed by ``python -m automation.main``."""
+
+    if uvicorn is None:
+        asyncio.run(_idle())
+    else:
+        asyncio.run(_serve())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Railway template that deploys planner and automation services from their respective monorepo roots with shared Postgres and Redis dependencies
- introduce environment variable template for Railway deployments and document the new workflow in the README
- stub an automation FastAPI entrypoint and update optional dependencies so Railway health checks can succeed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e0a9872d34832f87a78a196ed4838b