### PR TITLE
Add FastAPI and HTTPX to core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ readme = "README.md"
 requires-python = ">=3.11"
 authors = [{ name = "Rodex Team" }]
 dependencies = [
+  "fastapi>=0.111",
+  "httpx>=0.27",
   "structlog>=23.2",
   "pydantic>=2.5",
   "pydantic-settings>=2.0",


### PR DESCRIPTION
## Summary
- add FastAPI and HTTPX to the default dependency set so planner modules import cleanly without optional extras

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e0b1b40684832fb3aae1be77247847