### PR TITLE
Add automation command runner and smoke test CLI

### DIFF
--- a/docs/feature_opportunities.md
+++ b/docs/feature_opportunities.md
@@ -1,0 +1,68 @@
+# Feature Opportunities for the Rodex Platform
+
+This document expands on three strategic investments that can elevate the resiliency and usability of the Rodex platform. Each section recaps the motivating problem, points to the existing building blocks within the repository, and outlines measurable success criteria.
+
+## 1. Automated Template Update Validation Pipeline
+
+### Why it Matters
+- Railway template updates currently land without automated regression protection, increasing the risk of shipping broken planner or landing flows.
+
+### Existing Building Blocks
+- Automation service scaffold: `services/automation/main.py`
+- Deployment walkthrough detailing planner and landing endpoints: `README.md`
+
+### Implementation Steps
+1. Extend the automation service entry point so it can execute scripted smoke tests against the preview deployment created for template update PRs.
+2. Wire Railway PR deploys to call the automation runner, capturing pass/fail results and storing logs plus artifacts (screenshots, HAR files).
+3. Emit GitHub Check annotations summarizing the validation matrix to surface actionable feedback for reviewers.
+
+### Dependencies & Risks
+- Requires credentials for preview environments and secure object storage.
+- Playwright suites can extend CI runtime; prioritize a deterministic, minimal coverage set.
+
+### Success Indicators
+- Every template update PR shows validation status before review.
+- Mean review time drops because reviewers trust the automated signal.
+
+## 2. Gemini Streaming Observability Dashboard
+
+### Why it Matters
+- Gemini streaming reliability issues are difficult to diagnose without aggregated telemetry, prolonging incidents and masking regressions.
+
+### Existing Building Blocks
+- Streaming client implementation: `services/planner/gemini_stream.py`
+- Planner configuration surface for observability sinks: `services/planner/project_settings.py`
+
+### Implementation Steps
+1. Instrument the Gemini streaming client with counters and histograms capturing retry attempts, fallback usage, and latency distributions.
+2. Add tracing hooks around prompt planning flows so degraded streaming performance can be correlated with downstream automation impact.
+3. Publish the telemetry to the chosen metrics backend (e.g., OpenTelemetry exporter) and build Grafana/DataDog dashboards plus alerting rules.
+
+### Dependencies & Risks
+- Instrumentation must avoid blocking the streaming loop; prefer async-safe emission.
+- Metric naming should follow existing observability conventions to simplify adoption.
+
+### Success Indicators
+- Incident detection time decreases thanks to actionable dashboards.
+- Post-incident reviews cite dashboard insights when diagnosing root causes.
+
+## 3. Landing Prompt-to-Execution Feedback Loop
+
+### Why it Matters
+- The landing API stores prompt context in memory only, leaving users without visibility into automation progress after receiving a `job_id`.
+
+### Existing Building Blocks
+- Landing API implementation: `services/planner/landing_api.py`
+
+### Implementation Steps
+1. Persist prompt submissions and job metadata to a durable store (Redis or Postgres) via a planner-owned storage adapter.
+2. Emit lifecycle events (queued, running, succeeded, failed) from automation jobs that the landing API can relay via SSE or WebSockets.
+3. Update the frontend to display real-time progress, including links to generated artifacts or diffs.
+
+### Dependencies & Risks
+- Real-time endpoints require authentication, rate limiting, and data retention policies aligned with privacy expectations.
+- Streaming updates must degrade gracefully if clients disconnect or transports are unavailable.
+
+### Success Indicators
+- Users see immediate automation status without manual refreshes.
+- Support volume decreases as customers self-serve via transparent execution tracking.

--- a/services/automation/main.py
+++ b/services/automation/main.py
@@ -1,16 +1,19 @@
-"""Placeholder entrypoint for the automation service.
-
-This keeps the Railway deployment template functional until the
-Playwright automation runtime is implemented.
-"""
+"""Entrypoint and command runner for the automation service."""
 
 from __future__ import annotations
 
+import argparse
 import asyncio
+import json
 import logging
 import os
+import sys
+from pathlib import Path
+from typing import Iterable, Sequence
 
 from fastapi import FastAPI
+
+from .runner import CommandRunner, CommandSpec, format_summary
 
 try:
     import uvicorn
@@ -33,6 +36,121 @@ async def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
+def _split_commands(raw: str) -> list[str]:
+    """Parse command strings from the ``AUTOMATION_COMMANDS`` variable."""
+
+    parts: list[str] = []
+    for block in raw.splitlines():
+        for segment in block.split(";"):
+            item = segment.strip()
+            if item:
+                parts.append(item)
+    return parts
+
+
+def _load_commands_from_env() -> list[CommandSpec]:
+    raw = os.getenv("AUTOMATION_COMMANDS", "").strip()
+    if not raw:
+        return []
+    return [CommandSpec.from_config(value) for value in _split_commands(raw)]
+
+
+def _load_commands_from_file(path: Path) -> list[CommandSpec]:
+    data = json.loads(path.read_text())
+    if isinstance(data, list):
+        items = data
+    elif isinstance(data, dict) and "commands" in data:
+        items = data["commands"]
+    else:  # pragma: no cover - defensive branch
+        raise ValueError("Unsupported automation config format")
+    return [CommandSpec.from_config(item) for item in items]
+
+
+def _parse_environment_overrides(items: Iterable[str]) -> dict[str, str]:
+    overrides: dict[str, str] = {}
+    for item in items:
+        key, _, value = item.partition("=")
+        if not _:
+            msg = f"Invalid environment override '{item}'. Expected KEY=VALUE."
+            raise SystemExit(msg)
+        overrides[key.strip()] = value
+    return overrides
+
+
+def _commands_from_args(args: argparse.Namespace) -> list[CommandSpec]:
+    commands: list[CommandSpec] = []
+    if args.config is not None:
+        commands.extend(_load_commands_from_file(args.config))
+    for command in args.command:
+        commands.append(CommandSpec.from_config(command))
+    if not commands:
+        commands.extend(_load_commands_from_env())
+    return commands
+
+
+def _run_commands(args: argparse.Namespace) -> None:
+    commands = _commands_from_args(args)
+    if not commands:
+        raise SystemExit(
+            "No commands provided. Use --command, --config, or set AUTOMATION_COMMANDS."
+        )
+
+    overrides = _parse_environment_overrides(args.env)
+    runner = CommandRunner(
+        base_env={**os.environ, **overrides},
+        stop_on_failure=not args.keep_going,
+        default_timeout=args.timeout,
+    )
+    results = runner.run_sync(commands)
+    print(format_summary(results))
+
+    exit_code = 0 if all(result.passed for result in results) else results[-1].exit_code
+    sys.exit(exit_code)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Automation service utilities")
+    subparsers = parser.add_subparsers(dest="mode")
+    subparsers.required = False
+    parser.set_defaults(mode="serve")
+
+    subparsers.add_parser("serve", help="Run the FastAPI server")
+
+    run_parser = subparsers.add_parser("run", help="Execute smoke test commands sequentially")
+    run_parser.add_argument(
+        "--command",
+        "-c",
+        action="append",
+        default=[],
+        help="Command string to execute. Accepts multiple entries.",
+    )
+    run_parser.add_argument(
+        "--config",
+        type=Path,
+        help="Path to a JSON file describing commands.",
+    )
+    run_parser.add_argument(
+        "--env",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Environment overrides for the command run.",
+    )
+    run_parser.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        help="Default timeout (in seconds) applied to each command.",
+    )
+    run_parser.add_argument(
+        "--keep-going",
+        action="store_true",
+        help="Continue executing commands after a failure.",
+    )
+
+    return parser
+
+
 async def _serve() -> None:
     """Run the FastAPI application using Uvicorn."""
 
@@ -50,13 +168,21 @@ async def _idle() -> None:
         await asyncio.sleep(3600)
 
 
-def main() -> None:
-    """Entrypoint executed by ``python -m automation.main``."""
+def main(argv: Sequence[str] | None = None) -> None:
+    """Entrypoint executed by ``python -m services.automation.main``."""
 
-    if uvicorn is None:
-        asyncio.run(_idle())
-    else:
-        asyncio.run(_serve())
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.mode == "run":
+        _run_commands(args)
+    elif args.mode == "serve":
+        if uvicorn is None:
+            asyncio.run(_idle())
+        else:
+            asyncio.run(_serve())
+    else:  # pragma: no cover - defensive guard
+        parser.error(f"Unknown mode: {args.mode}")
 
 
 if __name__ == "__main__":

--- a/services/automation/runner.py
+++ b/services/automation/runner.py
@@ -1,0 +1,207 @@
+"""Utility helpers for executing automation commands sequentially."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shlex
+import time
+from dataclasses import dataclass
+from typing import Mapping, MutableMapping, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class CommandSpec:
+    """Serializable definition of a command to execute."""
+
+    label: str
+    argv: Sequence[str]
+    allow_failure: bool = False
+    env: Mapping[str, str] | None = None
+    timeout: float | None = None
+
+    @classmethod
+    def from_config(cls, value: object) -> "CommandSpec":
+        """Create a command specification from configuration input."""
+
+        if isinstance(value, CommandSpec):
+            return value
+        if isinstance(value, str):
+            argv = shlex.split(value)
+            return cls(label=value, argv=argv)
+        if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+            argv = [str(item) for item in value]
+            label = " ".join(argv)
+            return cls(label=label, argv=argv)
+        if isinstance(value, Mapping):
+            if "command" not in value:
+                raise ValueError("Command configuration requires a 'command' field")
+            raw_command = value["command"]
+            if isinstance(raw_command, str):
+                argv = shlex.split(raw_command)
+            elif isinstance(raw_command, Sequence):
+                argv = [str(item) for item in raw_command]
+            else:  # pragma: no cover - defensive branch
+                raise TypeError("Unsupported command specification type")
+            label = str(value.get("label") or value.get("name") or " ".join(argv))
+            allow_failure = bool(value.get("allow_failure", False))
+            env_value = value.get("env")
+            env: Mapping[str, str] | None
+            if env_value is None:
+                env = None
+            elif isinstance(env_value, Mapping):
+                env = {str(key): str(val) for key, val in env_value.items()}
+            else:  # pragma: no cover - defensive branch
+                raise TypeError("Environment overrides must be provided as a mapping")
+            timeout = value.get("timeout")
+            timeout_value = float(timeout) if timeout is not None else None
+            return cls(
+                label=label,
+                argv=argv,
+                allow_failure=allow_failure,
+                env=env,
+                timeout=timeout_value,
+            )
+        raise TypeError(f"Unsupported command specification: {value!r}")
+
+
+@dataclass(slots=True)
+class CommandResult:
+    """Outcome of a command execution."""
+
+    label: str
+    argv: Sequence[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    duration: float
+    allow_failure: bool
+    timed_out: bool
+
+    @property
+    def passed(self) -> bool:
+        """Return ``True`` when the command completed successfully."""
+
+        if self.timed_out:
+            return self.allow_failure
+        if self.returncode == 0:
+            return True
+        return self.allow_failure
+
+    @property
+    def exit_code(self) -> int:
+        """Return the exit code representing this result."""
+
+        if self.returncode != 0:
+            return self.returncode
+        return 0
+
+
+class CommandRunner:
+    """Execute shell commands sequentially with optional failure handling."""
+
+    def __init__(
+        self,
+        *,
+        base_env: Mapping[str, str] | None = None,
+        stop_on_failure: bool = True,
+        default_timeout: float | None = None,
+    ) -> None:
+        self._base_env = dict(base_env or {})
+        self._stop_on_failure = stop_on_failure
+        self._default_timeout = default_timeout
+
+    async def run(self, commands: Sequence[CommandSpec]) -> list[CommandResult]:
+        results: list[CommandResult] = []
+        for spec in commands:
+            result = await self._execute(spec)
+            results.append(result)
+            if not result.passed and self._stop_on_failure and not spec.allow_failure:
+                break
+        return results
+
+    def run_sync(self, commands: Sequence[CommandSpec]) -> list[CommandResult]:
+        """Synchronously execute commands for imperative callers."""
+
+        return asyncio.run(self.run(commands))
+
+    async def _execute(self, spec: CommandSpec) -> CommandResult:
+        env: MutableMapping[str, str] = dict(self._base_env)
+        if spec.env:
+            env.update(spec.env)
+
+        timeout = spec.timeout if spec.timeout is not None else self._default_timeout
+        start = time.perf_counter()
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *spec.argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+        except FileNotFoundError as exc:  # pragma: no cover - exercised via tests indirectly
+            duration = time.perf_counter() - start
+            logger.error("Command failed to spawn", exc_info=exc)
+            return CommandResult(
+                label=spec.label,
+                argv=spec.argv,
+                returncode=127,
+                stdout="",
+                stderr=str(exc),
+                duration=duration,
+                allow_failure=spec.allow_failure,
+                timed_out=False,
+            )
+
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                process.communicate(), timeout=timeout
+            )
+            timed_out = False
+        except asyncio.TimeoutError:
+            process.kill()
+            stdout_bytes, stderr_bytes = await process.communicate()
+            timed_out = True
+
+        duration = time.perf_counter() - start
+        stdout = stdout_bytes.decode()
+        stderr = stderr_bytes.decode()
+        returncode = process.returncode if process.returncode is not None else 1
+
+        if timed_out:
+            logger.error("Command timed out", extra={"label": spec.label, "timeout": timeout})
+        elif returncode != 0:
+            logger.error("Command failed", extra={"label": spec.label, "returncode": returncode})
+        else:
+            logger.info("Command succeeded", extra={"label": spec.label, "duration": duration})
+
+        return CommandResult(
+            label=spec.label,
+            argv=spec.argv,
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+            duration=duration,
+            allow_failure=spec.allow_failure,
+            timed_out=timed_out,
+        )
+
+
+def format_summary(results: Sequence[CommandResult]) -> str:
+    """Return a human-readable summary of command execution results."""
+
+    lines = []
+    for result in results:
+        status = "PASS" if result.passed else "FAIL"
+        lines.append(f"[{status}] {result.label} ({result.duration:.2f}s)")
+        if result.stdout.strip():
+            lines.append("  stdout:")
+            for line in result.stdout.strip().splitlines():
+                lines.append(f"    {line}")
+        if result.stderr.strip():
+            lines.append("  stderr:")
+            for line in result.stderr.strip().splitlines():
+                lines.append(f"    {line}")
+    return "\n".join(lines)

--- a/tests/test_automation_runner.py
+++ b/tests/test_automation_runner.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import json
+
+from services.automation.runner import CommandRunner, CommandSpec, format_summary
+from services.automation.main import _load_commands_from_file
+
+
+def _python_cmd(code: str) -> CommandSpec:
+    return CommandSpec.from_config([sys.executable, "-c", code])
+
+
+def test_command_runner_executes_in_sequence(tmp_path: Path) -> None:
+    runner = CommandRunner(stop_on_failure=True, base_env={})
+    commands = [
+        _python_cmd("print('first')"),
+        CommandSpec.from_config(
+            {
+                "command": [sys.executable, "-c", "import os; print(os.environ['SMOKE_TOKEN'])"],
+                "env": {"SMOKE_TOKEN": "demo"},
+            }
+        ),
+    ]
+
+    results = runner.run_sync(commands)
+
+    assert len(results) == 2
+    assert results[0].passed is True
+    assert results[0].stdout.strip() == "first"
+    assert results[1].stdout.strip() == "demo"
+
+
+def test_command_runner_stops_on_failure() -> None:
+    runner = CommandRunner(stop_on_failure=True, base_env={})
+    commands = [
+        _python_cmd("import sys; sys.exit(2)"),
+        _python_cmd("print('should not run')"),
+    ]
+
+    results = runner.run_sync(commands)
+
+    assert len(results) == 1
+    assert results[0].passed is False
+    assert results[0].returncode == 2
+
+
+def test_command_runner_honors_allow_failure() -> None:
+    runner = CommandRunner(stop_on_failure=True, base_env={})
+    commands = [
+        CommandSpec.from_config(
+            {
+                "command": [sys.executable, "-c", "import sys; sys.exit(3)"],
+                "allow_failure": True,
+            }
+        ),
+        _python_cmd("print('executed')"),
+    ]
+
+    results = runner.run_sync(commands)
+
+    assert len(results) == 2
+    assert results[0].passed is True
+    assert results[1].stdout.strip() == "executed"
+
+
+def test_command_spec_from_json_file(tmp_path: Path) -> None:
+    payload = {
+        "commands": [
+            {
+                "label": "say",
+                "command": [sys.executable, "-c", "print('hi')"],
+            }
+        ]
+    }
+    path = tmp_path / "commands.json"
+    path.write_text(json.dumps(payload))
+
+    specs = _load_commands_from_file(path)
+    runner = CommandRunner(base_env={})
+    results = runner.run_sync(specs)
+
+    assert results[0].passed is True
+    assert results[0].stdout.strip() == "hi"
+
+
+def test_format_summary_includes_output() -> None:
+    runner = CommandRunner(base_env={})
+    commands = [_python_cmd("print('summary')")]
+    results = runner.run_sync(commands)
+
+    summary = format_summary(results)
+
+    assert "summary" in summary


### PR DESCRIPTION
## Summary
- extend the automation service entrypoint with a CLI that can execute configured smoke test commands and honor environment overrides
- implement an asyncio-based command runner that handles sequential execution, timeouts, and structured output summaries
- add pytest coverage for the command runner configuration parsing, failure handling, and summary formatting helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e0af12eb54832f992511787320ee55