### PR TITLE
Fix setuptools package discovery for Nixpacks build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ automation = [
 ]
 
 [tool.setuptools.packages.find]
-where = ["services"]
+where = ["."]
+include = ["services*"]
 
 [tool.setuptools.package-data]
 "services.planner" = ["_data/*.json"]


### PR DESCRIPTION
## Summary
- adjust setuptools package discovery to search from the repository root
- ensure the package install step succeeds even when the `services` directory is not present in the build context

## Testing
- python -m pip install . -q

------
https://chatgpt.com/codex/tasks/task_b_68e0bc3d4174832f904c44fd89678bb8