### PR TITLE
Add branded icons and metadata to Railway templates

### DIFF
--- a/docs/assets/icons/rodex-automation-icon.svg
+++ b/docs/assets/icons/rodex-automation-icon.svg
@@ -1,0 +1,17 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="automationGradient" x1="36" y1="52" x2="220" y2="204" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#00D1FF" />
+      <stop offset="1" stop-color="#0061FF" />
+    </linearGradient>
+    <filter id="automationShadow" x="12" y="28" width="232" height="232" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="10" stdDeviation="14" flood-opacity="0.16" />
+    </filter>
+  </defs>
+  <g filter="url(#automationShadow)">
+    <path d="M128 48C83.8172 48 48 83.8172 48 128C48 172.183 83.8172 208 128 208C172.183 208 208 172.183 208 128C208 83.8172 172.183 48 128 48ZM128 184C97.4903 184 72 158.51 72 128C72 97.4903 97.4903 72 128 72C158.51 72 184 97.4903 184 128C184 158.51 158.51 184 128 184Z" fill="url(#automationGradient)" />
+  </g>
+  <path d="M152 104L176 128L152 152" stroke="#061224" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M104 152L80 128L104 104" stroke="#061224" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M128 96V160" stroke="#061224" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/docs/assets/icons/rodex-cache-icon.svg
+++ b/docs/assets/icons/rodex-cache-icon.svg
@@ -1,0 +1,11 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="cacheGradient" x1="44" y1="44" x2="208" y2="212" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFB347" />
+      <stop offset="1" stop-color="#FF5E62" />
+    </linearGradient>
+  </defs>
+  <path d="M60 84C60 66.3269 74.3269 52 92 52H164C181.673 52 196 66.3269 196 84V100H220C229.941 100 238 108.059 238 118V194C238 203.941 229.941 212 220 212H36C26.0589 212 18 203.941 18 194V118C18 108.059 26.0589 100 36 100H60V84Z" fill="url(#cacheGradient)" />
+  <path d="M96 132H160M96 164H160" stroke="#351000" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+  <rect x="72" y="40" width="112" height="36" rx="18" stroke="#351000" stroke-width="12" />
+</svg>

--- a/docs/assets/icons/rodex-database-icon.svg
+++ b/docs/assets/icons/rodex-database-icon.svg
@@ -1,0 +1,12 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="databaseGradient" x1="40" y1="32" x2="216" y2="224" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#54E0A7" />
+      <stop offset="1" stop-color="#008F7A" />
+    </linearGradient>
+  </defs>
+  <ellipse cx="128" cy="68" rx="80" ry="36" fill="url(#databaseGradient)" />
+  <path d="M48 68V188C48 210.091 82.8629 228 128 228C173.137 228 208 210.091 208 188V68" stroke="#063327" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+  <path d="M48 108C48 130.091 82.8629 148 128 148C173.137 148 208 130.091 208 108" stroke="#063327" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M48 148C48 170.091 82.8629 188 128 188C173.137 188 208 170.091 208 148" stroke="#063327" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/docs/assets/icons/rodex-template-icon.svg
+++ b/docs/assets/icons/rodex-template-icon.svg
@@ -1,0 +1,24 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="rodexGradient" x1="52" y1="36" x2="212" y2="220" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5B8CFF" />
+      <stop offset="0.5" stop-color="#7F5BFF" />
+      <stop offset="1" stop-color="#FF6AD5" />
+    </linearGradient>
+    <radialGradient id="rodexGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(128 128) scale(120)">
+      <stop stop-color="#FFFFFF" stop-opacity="0.35" />
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0" />
+    </radialGradient>
+    <filter id="shadow" x="26" y="18" width="204" height="240" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="8" stdDeviation="12" flood-opacity="0.18" />
+    </filter>
+  </defs>
+  <g filter="url(#shadow)">
+    <path d="M128 36L202 78V178L128 220L54 178V78L128 36Z" fill="url(#rodexGradient)" />
+  </g>
+  <circle cx="128" cy="128" r="90" fill="url(#rodexGlow)" />
+  <path d="M168 116C168 102.745 157.255 92 144 92H124C110.745 92 100 102.745 100 116V124C100 137.255 110.745 148 124 148H140C143.314 148 146 150.686 146 154C146 157.314 143.314 160 140 160H112" stroke="#0B1026" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="104" cy="170" r="10" fill="#0B1026" />
+  <circle cx="176" cy="154" r="10" fill="#0B1026" />
+  <path d="M176 154C189.255 154 200 143.255 200 130C200 116.745 189.255 106 176 106" stroke="#0B1026" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/railway.json
+++ b/railway.json
@@ -1,13 +1,23 @@
 {
   "$schema": "https://railway.app/railway.schema.json",
-  "build": {
-    "builder": "NIXPACKS",
-    "buildCommand": "python -m pip install --upgrade pip && pip install -e .[planner,automation] && python -m playwright install-deps && python -m playwright install chromium"
-  },
-  "deploy": {
-    "startCommand": "uvicorn services.planner.landing_api:create_app --host 0.0.0.0 --port ${PORT:-8080}",
-    "healthcheckPath": "/health",
-    "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 10
+  "name": "Rodex Planner",
+  "description": "Deploy the Rodex planner service with Playwright tooling on Railway.",
+  "icon": "https://raw.githubusercontent.com/codedwithlikhon/Rodex/main/docs/assets/icons/rodex-template-icon.svg",
+  "services": {
+    "web": {
+      "name": "Planner Service",
+      "description": "FastAPI planner API backed by Gemini, Playwright, PostgreSQL, and Redis.",
+      "icon": "https://raw.githubusercontent.com/codedwithlikhon/Rodex/main/docs/assets/icons/rodex-template-icon.svg",
+      "build": {
+        "builder": "NIXPACKS",
+        "buildCommand": "python -m pip install --upgrade pip && pip install -e .[planner,automation] && python -m playwright install-deps && python -m playwright install chromium"
+      },
+      "deploy": {
+        "startCommand": "uvicorn services.planner.landing_api:create_app --host 0.0.0.0 --port ${PORT:-8080}",
+        "healthcheckPath": "/health",
+        "restartPolicyType": "ON_FAILURE",
+        "restartPolicyMaxRetries": 10
+      }
+    }
   }
 }

--- a/railway.template.json
+++ b/railway.template.json
@@ -2,8 +2,13 @@
   "$schema": "https://railway.app/railway.schema.json",
   "name": "Rodex - Autonomous Web Automation",
   "description": "AI-powered task planning and browser automation with Gemini and Playwright.",
-  "icon": "🤖",
-  "tags": ["automation", "ai", "playwright", "python"],
+  "icon": "https://raw.githubusercontent.com/codedwithlikhon/Rodex/main/docs/assets/icons/rodex-template-icon.svg",
+  "tags": [
+    "automation",
+    "ai",
+    "playwright",
+    "python"
+  ],
   "repository": "https://github.com/codedwithlikhon/Rodex",
   "services": {
     "planner": {
@@ -42,7 +47,8 @@
         "DATABASE_URL": "${{postgres.DATABASE_URL}}",
         "REDIS_URL": "${{redis.REDIS_URL}}",
         "AUTOMATION_URL": "http://${{automation.RAILWAY_PRIVATE_DOMAIN}}"
-      }
+      },
+      "icon": "https://raw.githubusercontent.com/codedwithlikhon/Rodex/main/docs/assets/icons/rodex-template-icon.svg"
     },
     "automation": {
       "name": "Automation Service",
@@ -82,7 +88,8 @@
           "name": "playwright-cache",
           "mountPath": "/data"
         }
-      ]
+      ],
+      "icon": "https://raw.githubusercontent.com/codedwithlikhon/Rodex/main/docs/assets/icons/rodex-automation-icon.svg"
     },
     "postgres": {
       "name": "PostgreSQL",
@@ -91,11 +98,13 @@
         "POSTGRES_DB": "rodex",
         "POSTGRES_USER": "rodex",
         "POSTGRES_PASSWORD": "${{secret(32)}}"
-      }
+      },
+      "icon": "https://raw.githubusercontent.com/codedwithlikhon/Rodex/main/docs/assets/icons/rodex-database-icon.svg"
     },
     "redis": {
       "name": "Redis Cache",
-      "template": "redis"
+      "template": "redis",
+      "icon": "https://raw.githubusercontent.com/codedwithlikhon/Rodex/main/docs/assets/icons/rodex-cache-icon.svg"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add descriptive metadata and icons to the default Railway template definition
- publish reusable SVG icons for planner, automation, database, and cache services
- update the multi-service Railway template to reference the new artwork and metadata

## Testing
- not run (config-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68e0c0f64db4832f8d3605af22b333d3